### PR TITLE
Enable ignore file selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,5 @@ The above command traverses a directory or file and creates a .json file of a ke
 The hash of a half-full 512 GB drive yielded a ~300MB .json file so watch out for that.
 
 Use `--drive` to hash the entire system drive. There is also a `--compare` flag to compare changes in the hashes. A second (or more) hash needs to be created before using the `--compare` flag.
+
+An `--ignore` flag allows choosing a set of ignore patterns. Available options are `mac`, `win10` and `win11`.


### PR DESCRIPTION
## Summary
- allow choosing ignore pattern file via `--ignore`
- default to `mac` ignore patterns
- document ignore flag in README

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686899d2db08832192becb2c5e83f6b7